### PR TITLE
Add optional SVG normalizer

### DIFF
--- a/main/index.html
+++ b/main/index.html
@@ -41,6 +41,7 @@
 		const axios = require('axios').default;
 		const http = require('http');
 		const path = require('path');
+		const svgPreProcessor = require('@deepnest/svg-preprocessor');
 
 		ready(async function () {
 			// main navigation
@@ -90,7 +91,8 @@
 				dxfImportScale: "1",
 				dxfExportScale: "72",
 				endpointTolerance: 0.36,
-				conversionServer: defaultConversionServer
+				conversionServer: defaultConversionServer,
+				useSvgPreProcessor: false,
 			};
 
 			// Removed `electron-settings` while keeping the same interface to minimize changes
@@ -133,7 +135,7 @@
 						}
 					}
 
-					if (key == 'mergeLines' || key == 'simplify') {
+					if (key == 'mergeLines' || key == 'simplify' || key == 'useSvgPreProcessor') {
 						val = i.checked;
 					}
 
@@ -232,7 +234,7 @@
 					else if (i.getAttribute('data-conversion') == 'true') {
 						i.value = c[i.getAttribute('data-config')] / scale.value;
 					}
-					else if (key == 'mergeLines' || key == 'simplify') {
+					else if (key == 'mergeLines' || key == 'simplify' || key == 'useSvgPreProcessor') {
 						i.checked = c[i.getAttribute('data-config')];
 					}
 					else {
@@ -668,7 +670,17 @@
 
 							// dirpath is used for loading images embedded in svg files
 							// converted svgs will not have images
-							importData(body, filename, null, con, dxfFlag);
+							if (config.getSync('useSvgPreProcessor')) {
+								const svgResult = svgPreProcessor.loadSvgString(body);
+								if (!svgResult.success) {
+									message(svgResult.result, true);
+								} else {
+									importData(svgResult.result, filename, null, con, dxfFlag);
+								}
+							} else {
+								importData(body, filename, null, con, dxfFlag);
+							}
+
 						}
 					}).catch(err => {
 						message('could not contact file conversion server', true);
@@ -684,8 +696,16 @@
 					}
 					var filename = path.basename(filepath);
 					var dirpath = path.dirname(filepath);
-
-					importData(data, filename, dirpath, null);
+					if (config.getSync('useSvgPreProcessor')) {
+						const svgResult = svgPreProcessor.loadSvgString(data);
+						if (!svgResult.success) {
+							message(svgResult.result, true);
+						} else {
+							importData(svgResult.result, filename, null);
+						}
+					} else {
+						importData(data, filename, dirpath, null);
+					}
 				});
 			};
 
@@ -1807,6 +1827,11 @@
 
 				<h1>Import/Export</h1>
 				<dl class="formgroup">
+					<dt>Use SVG Normalizer?</dt>
+					<dd>
+						<input id="useSvgPreProcessor" type="checkbox" data-config="useSvgPreProcessor" />
+					</dd>
+
 					<dt>SVG scale</dt>
 					<dd>
 						<input id="inputscale" type="number" value="72" min="1" step="any" data-config="scale" required />

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "license": "MIT",
       "dependencies": {
         "@deepnest/calculate-nfp": "*",
+        "@deepnest/svg-preprocessor": "*",
         "@electron/remote": "^2.1.2",
         "axios": "^1.7.9",
         "form-data": "^4.0.1",
@@ -48,6 +49,222 @@
       "dependencies": {
         "nan": "^2.20.0",
         "node-gyp-build": "^4.8.4"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor/-/svg-preprocessor-0.1.2.tgz",
+      "integrity": "sha512-YvFGzfJCw+ArOKmmEokngOu8wAhospNR93SQfjTFNyNHvbOY+g8HOgWtL2fyaoUFFOMSNqfuYBlaG4Ih8sRDJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@deepnest/svg-preprocessor-darwin-arm64": "0.1.2",
+        "@deepnest/svg-preprocessor-darwin-x64": "0.1.2",
+        "@deepnest/svg-preprocessor-freebsd-x64": "0.1.2",
+        "@deepnest/svg-preprocessor-linux-arm-gnueabihf": "0.1.2",
+        "@deepnest/svg-preprocessor-linux-arm-musleabihf": "0.1.2",
+        "@deepnest/svg-preprocessor-linux-arm64-gnu": "0.1.2",
+        "@deepnest/svg-preprocessor-linux-arm64-musl": "0.1.2",
+        "@deepnest/svg-preprocessor-linux-riscv64-gnu": "0.1.2",
+        "@deepnest/svg-preprocessor-linux-x64-gnu": "0.1.2",
+        "@deepnest/svg-preprocessor-linux-x64-musl": "0.1.2",
+        "@deepnest/svg-preprocessor-win32-arm64-msvc": "0.1.2",
+        "@deepnest/svg-preprocessor-win32-ia32-msvc": "0.1.2",
+        "@deepnest/svg-preprocessor-win32-x64-msvc": "0.1.2"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-darwin-arm64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-darwin-arm64/-/svg-preprocessor-darwin-arm64-0.1.2.tgz",
+      "integrity": "sha512-k+TkTGLekJpZJaBOx7M8xIWKbR17Y1IF8oMnOzQJttEfhzmutcu/ZhwwDqGBEmaHVoQm1Y1tG3DTznv5wf87qw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-darwin-x64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-darwin-x64/-/svg-preprocessor-darwin-x64-0.1.2.tgz",
+      "integrity": "sha512-5PHUHjp6q5f8I0vjdhUMNrEwdiA12TgPRkP+bTyX1Qhf3avZcjjbWt0p/pq4IL0KRW5CUXF1X3O+dZZkF7iY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-linux-arm-gnueabihf": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-linux-arm-gnueabihf/-/svg-preprocessor-linux-arm-gnueabihf-0.1.2.tgz",
+      "integrity": "sha512-sbgZZ3V+uhoqCC9kTBftlSJ2ItOY2waLSKK/ms1p9admmuBmI+FceSlWuIZ9gEsH4bwhrpj1S6HtlV2zzLehmw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-linux-arm-musleabihf": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-linux-arm-musleabihf/-/svg-preprocessor-linux-arm-musleabihf-0.1.2.tgz",
+      "integrity": "sha512-m9kucWXhR3NQ8P7DkvUL5Ki6+4jXa2jFQG2mYI6zJV99f2+NoKijGmWDlPgOhdb1rId7EaGj9siSLvSWbr5wNg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-linux-arm64-gnu": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-linux-arm64-gnu/-/svg-preprocessor-linux-arm64-gnu-0.1.2.tgz",
+      "integrity": "sha512-utTcjMuni7sHtJaSYC+Ar73Rk7xoHTHsIJwhf61sngTeUEBh+yaxvC2bpm990ij5MVKVlP0hb3DNWwAr3Mdx2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-linux-arm64-musl": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-linux-arm64-musl/-/svg-preprocessor-linux-arm64-musl-0.1.2.tgz",
+      "integrity": "sha512-VvDpbAaVaoOUCupmiUqfstwGZUNraRka/QjvZQkugMW2uEWaOIOLsnnMmAEQrJzOxiF3hxsKNcIbDDhqNHCaVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-linux-riscv64-gnu": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-linux-riscv64-gnu/-/svg-preprocessor-linux-riscv64-gnu-0.1.2.tgz",
+      "integrity": "sha512-LATiBIUt+cqnFruJIxh9az/SWa6qfMxGL5rxpwufUJFMfKRB6u8RGkDfUK9wZsehEHLq3t5rVIpqQFyXEXD5ew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-linux-x64-gnu": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-linux-x64-gnu/-/svg-preprocessor-linux-x64-gnu-0.1.2.tgz",
+      "integrity": "sha512-1AmLQydigWZZt90EtA2q/e/gR+WUGhPUMDE0c6oWlG4v8gBK2UySV4qKjZm7m2DkazLzsuc2J3fqPJBGzb3Ibw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-linux-x64-musl": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-linux-x64-musl/-/svg-preprocessor-linux-x64-musl-0.1.2.tgz",
+      "integrity": "sha512-oAWfLIfRoyn8trlSrPx/khQL+UXtacKL9bSZ3lVynL7rhy0Tzvizni91pZA39e4vpT1KLD1xw5YvgvyHeLeICA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-win32-arm64-msvc": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-win32-arm64-msvc/-/svg-preprocessor-win32-arm64-msvc-0.1.2.tgz",
+      "integrity": "sha512-7D3onoks86qlb2N9NwQSky7UyjPtNOP76yU0IP53AOASY2TazkLxXLU+J83hEzCuDSs4FDU5Si8sA+1x1gpYYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-win32-ia32-msvc": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-win32-ia32-msvc/-/svg-preprocessor-win32-ia32-msvc-0.1.2.tgz",
+      "integrity": "sha512-BKTHw5nOAc+evWqAPoxfDMs1SjR7yalmYhwZFRDbCa0mTMmjoNblhVhQuOJJN8xzNnZZ9782GAMgUzJUTlU21A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepnest/svg-preprocessor-win32-x64-msvc": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepnest/svg-preprocessor-win32-x64-msvc/-/svg-preprocessor-win32-x64-msvc-0.1.2.tgz",
+      "integrity": "sha512-pp3gIRlOm3Hw2zA2nHTlkCgcNmq1FmwRnDeJ4exoJOgL3BCT3YSRX+2YcftIHK5kRnKj1ooDeaVbOgNnxBKZvg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@electron/asar": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@electron/remote": "^2.1.2",
     "@deepnest/calculate-nfp": "*",
+    "@deepnest/svg-preprocessor": "*",
     "axios": "^1.7.9",
     "form-data": "^4.0.1",
     "graceful-fs": "^4.2.11"


### PR DESCRIPTION
This change converts all SVG elements (rect, circle, etc.) to paths and handles them. It will create a flat SVG, any groupings will be lifted. At the moment there is no negative influence on the SVG parser, probably because of the many possibilities. In current tests with the SVG's available to me, there were no errors and the objects were correctly parsed and displayed.

Added a new configuration item ("Use SVG Normalizer?") that can be toggled on and off.