### PR TITLE
v1/refactor/converter-url-fix

### DIFF
--- a/examples/app_notifications.json
+++ b/examples/app_notifications.json
@@ -27,10 +27,14 @@
       "date": "2023-09-19T00:00:00Z",
       "title": "Ads for Deepnest",
       "content": "<h2>Introducing Deepnest Pro</h2><p>Upgrade to Deepnest Pro for advanced nesting features, priority support, and ad-free experience!</p><p>Get started today and take your nesting to the next level.</p><p><a href='https://www.deepnest.net/pro'>Upgrade Now</a></p>"
+    },
+    {
+      "title": "Online converter down",
+      "type": "important",
+      "date": "2025-03-22T12:00:00.000Z",
+      "uuid": "notifications_1970-03-22_1200-002",
+      "content": "<h2>How to replace</h2>\n<p style=\"font-size: 16px; line-height: 1.6; margin-bottom: 15px;\">\nYesterday I was informed that the converter API of <a href=\"https://convert.deepnest.io\" target=\"_blank\" style=\"color: #007bff; text-decoration: none;\">convert.deepnest.io</a> is no longer available. Since there were no changes after the usual up to 60 minutes. So I quickly put together an API for you. Actually I wasn't ready yet, but after 8 hours I could at least report a success for my tests and provide instructions on how you can overwrite the converter until the next update</p>\n<p style=\"font-size: 16px; line-height: 1.6; margin-bottom: 15px;\">You can find more information at: <a href=\"https://github.com/deepnest-next/deepnest/issues/71#issuecomment-2744963030\" target=\"_blank\" style=\"color: #007bff; text-decoration: none;\">GitHub comment</a></p>\n<p style=\"font-size: 14px; color: #777; text-align: center; margin-top: 30px;\">Greetings, Josef<br>From your deepnest-next team!</p>\n"
     }
   ],
-  "meta": {
-    "lastUpdated": "2023-11-01T10:15:30Z",
-    "version": "1.0.0"
-  }
+  "meta": { "lastUpdated": "2025-03-22T16:56:44.630Z", "version": "1.5.0" }
 }

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, ipcMain, BrowserWindow, screen } = require("electron");
+const { app, ipcMain, BrowserWindow, screen, shell } = require("electron");
 const remote = require("@electron/remote/main");
 const fs = require("graceful-fs");
 const path = require("path");
@@ -103,6 +103,11 @@ function createMainWindow() {
 
   remote.enable(mainWindow.webContents);
 
+  mainWindow.webContents.setWindowOpenHandler((details) => {
+    shell.openExternal(details.url);
+    return { action: 'deny' }
+  })
+
   // and load the index.html of the app.
   mainWindow.loadURL(
     url.format({
@@ -163,6 +168,10 @@ function createNotificationWindow(notification) {
   });
 
   remote.enable(notificationWindow.webContents);
+  notificationWindow.webContents.setWindowOpenHandler((details) => {
+    shell.openExternal(details.url);
+    return { action: 'deny' }
+  })
 
   notificationWindow.loadURL(
     url.format({

--- a/main/page.js
+++ b/main/page.js
@@ -203,7 +203,7 @@ ready(async function () {
     // config form
 
 
-    const defaultConversionServer = 'http://convert.deepnest.io';
+    const defaultConversionServer = 'https://converter.deepnest.app/convert';
 
     var defaultconfig = {
         units: 'inch',

--- a/main/page.js
+++ b/main/page.js
@@ -739,9 +739,9 @@ ready(async function () {
         dialog.showOpenDialog({
             filters: [
 
-                { name: 'CAD formats', extensions: ['svg', 'dxf'] },
-                { name: 'SVG', extensions: ['svg'] },
-                { name: 'DXF', extensions: ['dxf'] }
+                { name: 'CAD formats', extensions: ['svg', 'ps', 'eps', 'dxf', 'dwg'] },
+                { name: 'SVG/EPS/PS', extensions: ['svg','eps','ps'] },
+                { name: 'DXF/DWG', extensions: ['dxf','dwg'] }
 
             ],
             properties: ['openFile', 'multiSelections']
@@ -1232,7 +1232,7 @@ ready(async function () {
         var fileName = dialog.showSaveDialogSync({
             title: 'Export deepnest DXF',
             filters: [
-                { name: 'DXF', extensions: ['dxf'] }
+                { name: 'DXF/DWG', extensions: ['dxf','dwg'] }
             ]
         })
 
@@ -1241,9 +1241,8 @@ ready(async function () {
         }
         else {
 
-            var fileExt = '.dxf';
             var filePathExt = fileName;
-            if (!fileName.toLowerCase().endsWith(fileExt)) {
+            if (!fileName.toLowerCase().endsWith('.dxf') && !fileName.toLowerCase().endsWith('.dwg')) {
                 fileName = fileName + fileExt;
             }
 

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -99,7 +99,7 @@ test("Nest", async ({}, testInfo) => {
     };
     expect(config).toMatchObject({
       ...sharedConfig,
-      conversionServer: "http://convert.deepnest.io",
+      conversionServer: "https://converter.deepnest.app/convert",
       dxfExportScale: "72",
       dxfImportScale: "1",
       endpointTolerance: 0.36,


### PR DESCRIPTION
Change the http://convert.deepnest.io url to selfhosted converter, hosted under https://converter.deepnest.app.

This are now hosted in the EU and under my (@Dexus) own controll, in order to guarantee data protection.

Features:
- 50 MB filesize (50*1024*1024) for the complete POST size
- Support Pairs: svg/dxf, dxf/svg, dwg/svg, eps/dxf, ps/dxf
- Use currently inkscape 1.4 as backend processor
  - will also check in the future if we can use also other tools that match some file formats better then inkscape at the moment
  - will include also some commercial products for conversation between file formats (not yet public)
- All what can used unter opensource Licenses, willl published soon in [deepnest-next/convert-server](https://github.com/deepnest-next/convert-server), because we also work with integrations of commercial products, we can't publish the complete code.
- Publishing API on 2025-02-01 also the source to github [deepnest-next/convert-server](https://github.com/deepnest-next/convert-server)

Used components:
- pstoedit (http://www.calvina.de/pstoedit/) - thanks Wolfgang for the v4.03 version which will currently not included (will released in the feature)
- inkscape

This own backend-service will also fixes #12, #71