### PR TITLE
Allow MaxListeners for emitter of 30

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const path = require("path");
 const os = require("os");
 const url = require("url");
 const { loadPresets, savePreset, deletePreset } = require("./presets");
+require("events").EventEmitter.defaultMaxListeners = 30;
 
 remote.initialize();
 


### PR DESCRIPTION
This pull request includes a small change to the `main.js` file. The change sets the default maximum number of event listeners for `EventEmitter` to 30.

* [`main.js`](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR7): Added a line to set `require("events").EventEmitter.defaultMaxListeners` to 30.