### PR TITLE
Refactor Build System for Linux and MacOS

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,7 +1,9 @@
-name: build release for linux
+name: build release
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build-and-release:
@@ -29,7 +31,7 @@ jobs:
         id: set_arch
         run: |
           # Check if the runner OS includes "arm" and set the ARCH environment variable accordingly
-          if [[ "${{ matrix.os }}" == *arm* ]]; then
+          if [[ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]]; then
             echo "ARCH=arm64" >> $GITHUB_ENV
           else
             echo "ARCH=x64" >> $GITHUB_ENV
@@ -62,7 +64,85 @@ jobs:
           # Retrieve the release tag from the previous step
           TAG=${{ steps.get_release.outputs.tag }}
           # Set the build directory name using the release tag and architecture
-          BUILD_DIR="deepnest-${TAG}-linux-${ARCH}"
+          BUILD_DIR="deepnest-${TAG}-${BUILD_FOR_OS}-${ARCH}"
+          echo "Creating build in: $BUILD_DIR"
+          # Run Electron Packager to package the application into the specified build directory
+          npx @electron/packager . "deepnest-${TAG}" --overwrite
+          # Zip the build directory with the same name
+          zip -r "${BUILD_DIR}.zip" "$BUILD_DIR"
+      - name: Artefakt an letztes Release anhängen
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: deepnest-${{ steps.get_release.outputs.tag }}-${{ env.BUILD_FOR_OS}}-${{ env.ARCH }}.zip
+          asset_name: deepnest-${{ steps.get_release.outputs.tag }}-${{ env.BUILD_FOR_OS}}-${{ env.ARCH }}.zip
+          asset_content_type: application/zip
+
+
+
+  build-and-release-macos:
+    env:
+      BUILD_FOR_OS: darwin
+    strategy:
+      matrix:
+        node-version: [22.x]
+        os: [macos-13, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Boost (only for Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sudo apt-get update && sudo apt-get install -yq libboost-dev
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Set architecture
+        id: set_arch
+        run: |
+          # Check if the runner OS includes "arm" and set the ARCH environment variable accordingly
+          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            echo "ARCH=arm64" >> $GITHUB_ENV
+          else
+            echo "ARCH=x64" >> $GITHUB_ENV
+          fi
+          echo "Architecture set to: $ARCH"
+
+      - name: Get latest release
+        id: get_release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // Retrieve the latest release information using the GitHub API
+            const release = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            core.setOutput("upload_url", release.data.upload_url);
+            core.setOutput("release_id", release.data.id);
+            core.setOutput("tag", release.data.tag_name);
+            console.log("Found release:", release.data.tag_name);
+
+      - name: Build project
+        run: |
+          # Install dependencies and run the build script
+          npm install
+          npm run build
+
+      - name: Package build
+        run: |
+          # Retrieve the release tag from the previous step
+          TAG=${{ steps.get_release.outputs.tag }}
+          # Set the build directory name using the release tag and architecture
+          BUILD_DIR="deepnest-${TAG}-${BUILD_FOR_OS}-${ARCH}"
           echo "Creating build in: $BUILD_DIR"
           # Run Electron Packager to package the application into the specified build directory
           npx @electron/packager . "deepnest-${TAG}" --overwrite
@@ -75,6 +155,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: deepnest-${{ steps.get_release.outputs.tag }}-linux-${{ env.ARCH }}.zip
-          asset_name: deepnest-${{ steps.get_release.outputs.tag }}-linux-${{ env.ARCH }}.zip
+          asset_path: deepnest-${{ steps.get_release.outputs.tag }}-${{ env.BUILD_FOR_OS}}-${{ env.ARCH }}.zip
+          asset_name: deepnest-${{ steps.get_release.outputs.tag }}-${{ env.BUILD_FOR_OS}}-${{ env.ARCH }}.zip
           asset_content_type: application/zip


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow for building and releasing the project. The changes enhance the build process by adding support for macOS, adjusting the architecture detection, and improving the packaging steps.

### Enhancements to build and release workflow:

* **General Workflow Updates:**
  * Changed the workflow name from "build release for linux" to "build release" and added a trigger for published releases. (`.github/workflows/build_release.yml`)
  
* **Architecture Detection:**
  * Modified the architecture detection logic to specifically check for "ubuntu-24.04-arm" instead of any OS that includes "arm". (`.github/workflows/build_release.yml`)
  
* **Packaging and Release:**
  * Updated the build directory naming convention to include the target OS and added steps to package the application using Electron Packager and zip the build directory. (`.github/workflows/build_release.yml`)
  * Adjusted the asset path and name to include the target OS in the upload-release-asset step. (`.github/workflows/build_release.yml`)
  
* **macOS Build Support:**
  * Added a new job `build-and-release-macos` to support building and releasing the project on macOS, including steps for setting up the environment, installing dependencies, and packaging the build. (`.github/workflows/build_release.yml`)