### PR TITLE
move NFP Cache DB to own file

### DIFF
--- a/main/nfpDb.js
+++ b/main/nfpDb.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const { get } = require("http");
+
+
+function clone(nfp) {
+    var newnfp = [];
+    for (let i = 0; i < nfp.length; i++) {
+        newnfp.push({
+            x: nfp[i].x,
+            y: nfp[i].y
+        });
+    }
+
+    if (nfp.children && nfp.children.length > 0) {
+        newnfp.children = [];
+        for (let i = 0; i < nfp.children.length; i++) {
+            var child = nfp.children[i];
+            var newchild = [];
+            for (let j = 0; j < child.length; j++) {
+                newchild.push({
+                    x: child[j].x,
+                    y: child[j].y
+                });
+            }
+            newnfp.children.push(newchild);
+        }
+    }
+
+    return newnfp;
+}
+
+function cloneNfp(nfp, inner) {
+    if (!inner) {
+        return clone(nfp);
+    }
+
+    // inner nfp is actually an array of nfps
+    var newnfp = [];
+    for (let i = 0; i < nfp.length; i++) {
+        newnfp.push(clone(nfp[i]));
+    }
+
+    return newnfp;
+}
+
+const db = {};
+
+module.exports = {
+    has: function (obj) {
+        var key = this._makeKey(obj);
+        if (db[key]) {
+            return true;
+        }
+        return false;
+    },
+
+    find: function (obj, inner) {
+        var key = this._makeKey(obj, inner);;
+        //console.log('key: ', key);
+        if (db[key]) {
+            return cloneNfp(db[key], inner);
+        }
+        /*var keypath = './nfpcache/'+key+'.json';
+        if(fs.existsSync(keypath)){
+            // could be partially written
+            obj = null;
+            try{
+                obj = JSON.parse(fs.readFileSync(keypath).toString());
+            }
+            catch(e){
+                return null;
+            }
+            var nfp = obj.nfp;
+            nfp.children = obj.children;
+
+            window.nfpcache[key] = clone(nfp);
+
+            return nfp;
+        }*/
+        return null;
+    },
+
+    insert: function (obj, inner) {
+        var key = this._makeKey(obj, inner);
+        //if (window.performance.memory.totalJSHeapSize < 0.8 * window.performance.memory.jsHeapSizeLimit) {
+            db[key] = cloneNfp(obj.nfp, inner);
+            //console.log('cached: ',window.cache[key].poly);
+            //console.log('using', window.performance.memory.totalJSHeapSize/window.performance.memory.jsHeapSizeLimit);
+        //}
+
+        /*obj.children = obj.nfp.children;
+
+        var keypath = './nfpcache/'+key+'.json';
+        fq.writeFile(keypath, JSON.stringify(obj), function (err) {
+            if (err){
+                console.log("couldn't write");
+            }
+        });*/
+    },
+
+    getCache: function () {
+        return db;
+    },
+
+    getStats: function () {
+        return Object.keys(db).length;
+    },
+
+    _makeKey: function (doc, inner) {
+        const Arotation = parseInt(doc.Arotation);
+        const Brotation = parseInt(doc.Brotation);
+        // Include flipped state in the key
+        const Aflipped = doc.Aflipped ? '1' : '0';
+        const Bflipped = doc.Bflipped ? '1' : '0';
+        return `${doc.A}-${doc.B}-${Arotation}-${Brotation}-${Aflipped}-${Bflipped}`;
+    }
+}


### PR DESCRIPTION
This pull request includes significant changes to the caching mechanism and refactoring of the `main/background.js` file. The changes involve moving the caching logic to a new module, `nfpDb.js`, and updating the references in `main/background.js` accordingly.

Refactoring and modularization:

* Removed the `clone`, `cloneNfp`, and `window.db` functions from `main/background.js` and moved them to a new file `nfpDb.js` to improve code organization and maintainability. [[1]](diffhunk://#diff-73f5a0c098eeed918ec330da8ffc45e7f4ca600d9bb969d0a9dea4b5d2909c85L3-L98) [[2]](diffhunk://#diff-01ae89a290afbf83a336e2cb581a584b897edbd1ab25df7d08c11c1aeaa2b85eR1-R118)

* Updated `main/background.js` to require the new `nfpDb.js` module and use its methods for caching operations.

Caching improvements:

* Replaced the inline `window.nfpcache` object with a more structured `db` object in `nfpDb.js`, which includes methods for checking, finding, inserting, and retrieving cache statistics.

* Updated the synchronization function in `main/background.js` to use the `getStats` method from the new `nfpDb.js` module to log the number of cached items.