### PR TITLE
refactor: improve variable declarations and add marked property to Point class

### DIFF
--- a/main/util/matrix.ts
+++ b/main/util/matrix.ts
@@ -117,6 +117,7 @@ export class Matrix {
 
   matrix(m: Array<number>): Matrix;
   matrix(m: ArbitraryMatrix): Matrix;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   matrix(m: any): Matrix {
     this.cache = null;
     if (Array.isArray(m)) {
@@ -179,7 +180,7 @@ export class Matrix {
       return this.cache;
     }
 
-    var cache = this.v;
+    let cache = this.v;
     this.queue.forEach(
       (item) => (cache = Matrix.combine(cache, item.matrix6())),
     );
@@ -191,8 +192,6 @@ export class Matrix {
   // Apply list of matrixes to (x,y) point.
   // If `isRelative` set, `translate` component of matrix will be skipped
   calc(point: Point, isRelative?: boolean): Point {
-    var m;
-
     // Don't change point on empty transforms queue
     if (!this.queue.length) {
       return point;
@@ -207,7 +206,7 @@ export class Matrix {
       this.cache = this.toArray();
     }
 
-    m = this.cache;
+    const m = this.cache;
 
     // Apply matrix to point
     return new Point(
@@ -233,7 +232,7 @@ export class Matrix {
   applyTransformString(transformString: string): Matrix {
     if (!transformString) return this;
 
-    var operations = {
+    const operations = {
       matrix: true,
       scale: true,
       rotate: true,
@@ -246,8 +245,8 @@ export class Matrix {
       /\s*(matrix|translate|scale|rotate|skewX|skewY)\s*\(\s*(.+?)\s*\)[\s,]*/;
     const PARAMS_SPLIT_RE = /[\s,]+/;
 
-    var cmd: string = "";
-    var params: Array<number>;
+    let cmd: string = "";
+    let params: Array<number>;
 
     // Split value into ['', 'translate', '10 50', '', 'scale', '2', '', 'rotate',  '-45', '']
     for (const item of transformString.split(CMD_SPLIT_RE)) {
@@ -257,7 +256,7 @@ export class Matrix {
       }
 
       // remember operation
-      if (operations.hasOwnProperty(item)) {
+      if (Object.prototype.hasOwnProperty.call(operations, item)) {
         cmd = item;
         continue;
       }

--- a/main/util/point.ts
+++ b/main/util/point.ts
@@ -3,6 +3,7 @@ import { Vector } from "./vector.js";
 export class Point {
   x: number;
   y: number;
+  marked?: boolean; // For NFP generation
   constructor(x: number, y: number) {
     this.x = x;
     this.y = y;
@@ -38,7 +39,7 @@ export class Point {
   public equals(obj: Point): boolean {
     return this.x === obj.x && this.y === obj.y;
   }
-  public toString(): String {
+  public toString(): string {
     return "<" + this.x.toFixed(1) + ", " + this.y.toFixed(1) + ">";
   }
 }

--- a/main/util/vector.ts
+++ b/main/util/vector.ts
@@ -1,5 +1,5 @@
 // floating point comparison tolerance
-var TOL = Math.pow(10, -9); // Floating point error is likely to be above 1 epsilon
+const TOL = Math.pow(10, -9); // Floating point error is likely to be above 1 epsilon
 
 function _almostEqual(a: number, b: number, tolerance?: number) {
   if (!tolerance) {
@@ -34,7 +34,7 @@ export class Vector {
     if (_almostEqual(sqLen, 1)) {
       return this; // given vector was already a unit vector
     }
-    var len = Math.sqrt(sqLen);
+    const len = Math.sqrt(sqLen);
     return new Vector(this.dx / len, this.dy / len);
   }
 }


### PR DESCRIPTION
This pull request includes several updates to improve code readability, maintainability, and consistency across the `Matrix`, `Point`, and `Vector` classes in the `main/util` directory. The changes primarily involve replacing `var` with `let` or `const`, ensuring stricter type annotations, and enhancing code clarity.

### Code Consistency Improvements:

* Replaced all instances of `var` with `let` or `const` in the `Matrix`, `Point`, and `Vector` classes to align with modern JavaScript/TypeScript best practices. (`main/util/matrix.ts`: [[1]](diffhunk://#diff-85f30bbe20c9ca550faab634d3d4e80ce90e664629e636a1e3b3d403ee569778L182-R183) [[2]](diffhunk://#diff-85f30bbe20c9ca550faab634d3d4e80ce90e664629e636a1e3b3d403ee569778L210-R209) [[3]](diffhunk://#diff-85f30bbe20c9ca550faab634d3d4e80ce90e664629e636a1e3b3d403ee569778L236-R235) [[4]](diffhunk://#diff-85f30bbe20c9ca550faab634d3d4e80ce90e664629e636a1e3b3d403ee569778L249-R249); `main/util/vector.ts`: [[5]](diffhunk://#diff-cb3678928d0321f5d1607c35df4eed23a0af358ca9751cdc4d4bca3eef0d4144L2-R2) [[6]](diffhunk://#diff-cb3678928d0321f5d1607c35df4eed23a0af358ca9751cdc4d4bca3eef0d4144L37-R37)

* Updated the `toString` method in the `Point` class to return a `string` instead of `String`, ensuring stricter type annotations. (`main/util/point.ts`: [main/util/point.tsL41-R42](diffhunk://#diff-a3f01c7dec91b3a4f71757498b9753e2f8c750dd59268fb3f40dbc2dcaabc4c2L41-R42))

### Code Clarity Enhancements:

* Replaced `hasOwnProperty` calls with `Object.prototype.hasOwnProperty.call` for safer property checks in the `Matrix` class. (`main/util/matrix.ts`: [main/util/matrix.tsL260-R259](diffhunk://#diff-85f30bbe20c9ca550faab634d3d4e80ce90e664629e636a1e3b3d403ee569778L260-R259))

* Added a `marked` property to the `Point` class for potential use in NFP (No-Fit Polygon) generation, improving extensibility. (`main/util/point.ts`: [main/util/point.tsR6](diffhunk://#diff-a3f01c7dec91b3a4f71757498b9753e2f8c750dd59268fb3f40dbc2dcaabc4c2R6))

* Added an ESLint directive to suppress warnings for the use of `any` in the `Matrix` class, acknowledging the intentional design decision. (`main/util/matrix.ts`: [main/util/matrix.tsR120](diffhunk://#diff-85f30bbe20c9ca550faab634d3d4e80ce90e664629e636a1e3b3d403ee569778R120))