### PR TITLE
test: de-flake non-deterministic nesting Playwright test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-    timeout-minutes: 5
+    # Give the job enough headroom for the non-deterministic nester test to
+    # retry (playwright retries: 2) with its raised per-test timeout without the
+    # job-level timeout cutting a slow-but-valid run short. Flaky-test mitigation.
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     steps:
       - name: boost

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -15,6 +15,11 @@ import { DeepNestConfig, NestingResult } from "../index";
 // !process.env.CI && test.use({ launchOptions: { slowMo: 500 } });
 
 test("Nest", async ({}, testInfo) => {
+  // Flaky-test mitigation: the nester uses a non-deterministic genetic
+  // algorithm, so on slower CI runners it can take noticeably longer than the
+  // default 30s per-test timeout to place all 54 parts (54/54). Give it more
+  // headroom here rather than weakening the 54/54 correctness assertion below.
+  test.setTimeout(120_000);
   const { pipeConsole } = testInfo.config.metadata;
   if (existsSync(testInfo.outputDir)) {
     mkdir(testInfo.outputDir, { recursive: true });
@@ -180,11 +185,14 @@ test("Nest", async ({}, testInfo) => {
   await expect(
     mainWindow.locator("id=nestinfo").locator("h1").nth(0),
   ).toHaveText("1");
+  // Flaky-test mitigation: poll for the full 54/54 placement for up to 90s so
+  // the non-deterministic genetic algorithm reliably converges on slower CI
+  // runners. The expected part count stays at 54/54 (assertion unchanged).
   await expect(() =>
     expect(mainWindow.locator("id=nestinfo").locator("h1").nth(1)).toHaveText(
       "54/54",
     ),
-  ).toPass();
+  ).toPass({ timeout: 90_000 });
 
   await test.step("Attachments", async () => {
     const svg = await downloadSvg();


### PR DESCRIPTION
## Problem

The `Nest` Playwright test (`tests/index.spec.ts`) waits for the genetic-algorithm nester to place all parts and asserts that `#nestinfo h1` (2nd) reads `54/54`.

The genetic algorithm is **non-deterministic**. On slower CI runners it sometimes only reaches `53/54` within the default **30s per-test timeout** before the assertion polling gives up. Because the GA differs run to run, the failure can slip through all attempts even with `retries: 2` in `playwright.config.ts`.

This is **pre-existing flakiness, not a regression** — it has failed on `main` as well. The nesting result itself is correct; the test just doesn't always give the GA enough time to converge.

## Fix (minimal, no correctness weakening)

- `tests/index.spec.ts`: `test.setTimeout(120_000)` for this test so the GA has room to converge past the default 30s.
- `tests/index.spec.ts`: the `54/54` assertion now polls for up to 90s via `.toPass({ timeout: 90_000 })`. **The expected part count stays at `54/54`** — the correctness assertion is unchanged.
- `.github/workflows/playwright.yml`: bump job `timeout-minutes` 5 -> 15 so the raised per-test timeout plus retries isn't cut short by the job-level timeout.

Explicitly **not** done: nesting logic untouched, expected part count not lowered, no extra retries added as the "fix".

Each change is commented as a flaky-test mitigation.

## Verification

Config and test files pass a TypeScript/YAML syntax sanity check. The real signal is CI stability: please **re-run the Playwright workflow a few times** to confirm the test now reliably reaches `54/54`.