### PR TITLE
fix: guard notification-window null-race (crash on .show() of null)

### DIFF
--- a/main.js
+++ b/main.js
@@ -190,12 +190,17 @@ function createNotificationWindow(notification) {
   if (process.env["deepnest_debug"] === "1")
     notificationWindow.webContents.openDevTools();
 
-  notificationWindow.once("ready-to-show", () => {
-    notificationWindow.show();
+  // Capture a local reference: a previously-closed notification window emits
+  // its "closed" event asynchronously (after a new one may already exist), so
+  // nulling the shared `notificationWindow` unconditionally could clobber the
+  // current window and make `.show()` throw on null. Guard against that.
+  const win = notificationWindow;
+  win.once("ready-to-show", () => {
+    win.show();
   });
 
-  notificationWindow.on("closed", () => {
-    notificationWindow = null;
+  win.on("closed", () => {
+    if (notificationWindow === win) notificationWindow = null;
   });
 
   // Store the notification data for access by the renderer


### PR DESCRIPTION
### Problem
Launching the app can crash the main process with:
```
TypeError: Cannot read properties of null (reading 'show')
    at BrowserWindow.<anonymous> (main.js:194)
```

### Cause
`createNotificationWindow()` closes any existing notification window, then creates a new one and assigns it to the shared `notificationWindow`. The **old** window's `"closed"` event fires **asynchronously** (after the new window may already exist) and runs `notificationWindow = null`, clobbering the reference to the *current* window. The new window's `"ready-to-show"` handler then calls `notificationWindow.show()` on `null`.

### Fix
Capture a local `const win = notificationWindow` for the async `ready-to-show`/`closed` handlers, and only null the shared variable when it still points at the closing window (`if (notificationWindow === win)`). No behavior change beyond removing the race.

Relates to #147 (the periodic notification panel).