### PR TITLE
fix(notifications): stop popup hijacking the desktop + add opt-out setting

### DIFF
--- a/main.js
+++ b/main.js
@@ -156,8 +156,10 @@ function createNotificationWindow(notification) {
     width: 750,
     height: 500,
     parent: mainWindow,
-    alwaysOnTop: true,
-    type: "notification",
+    // NOTE: deliberately NOT `alwaysOnTop`/`type: "notification"`. Those forced
+    // the notification above every window on the OS (and, on some Linux WMs,
+    // kept re-raising it over other applications). `modal` + `parent` already
+    // keeps it above deepnest's own window without hijacking the whole desktop.
     center: true,
     maximizable: false,
     minimizable: false,
@@ -207,7 +209,27 @@ function createNotificationWindow(notification) {
   notificationWindow.notificationData = notification;
 }
 
+// Whether the user has opted in to product/update notifications. Defaults to
+// ON; only a config with `showNotifications === false` disables it. When off we
+// never fetch deepnest.net/app_notifications.json, so the app stays fully offline
+// for notifications. `configPath` is a module-scope const defined below; this is
+// only ever called at runtime (post-startup), so it is initialised by then.
+function notificationsEnabled() {
+  try {
+    if (fs.existsSync(configPath)) {
+      const cfg = JSON.parse(fs.readFileSync(configPath).toString());
+      return cfg.showNotifications !== false;
+    }
+  } catch (err) {
+    console.error("Could not read notification setting, defaulting to on:", err);
+  }
+  return true;
+}
+
 async function runNotificationCheck() {
+  if (!notificationsEnabled()) {
+    return;
+  }
   const notification = await notificationService.checkForNotifications();
   if (notification) {
     createNotificationWindow(notification);

--- a/main/index.html
+++ b/main/index.html
@@ -464,6 +464,14 @@
             <dd>
               <input type="checkbox" data-config="useQuantityFromFileName" />
             </dd>
+            <dt>
+              Show product &amp; update notifications
+              <small><br \ />fetched from deepnest.net; uncheck to stay fully
+              offline</small>
+            </dt>
+            <dd>
+              <input type="checkbox" data-config="showNotifications" />
+            </dd>
           </dl>
 
           <h1>Presets</h1>

--- a/main/ui/services/config.service.ts
+++ b/main/ui/services/config.service.ts
@@ -44,6 +44,7 @@ export const DEFAULT_CONFIG: Readonly<UIConfig> = {
   exportWithSheetBoundboarders: false,
   exportWithSheetsSpace: false,
   exportWithSheetsSpaceValue: 0.3937007874015748, // 10mm in inches
+  showNotifications: true, // show product/update notifications fetched from deepnest.net
 };
 
 /**
@@ -56,6 +57,7 @@ export const BOOLEAN_CONFIG_KEYS: ReadonlyArray<keyof UIConfig> = [
   "useQuantityFromFileName",
   "exportWithSheetBoundboarders",
   "exportWithSheetsSpace",
+  "showNotifications",
 ];
 
 /**
@@ -96,6 +98,7 @@ export class ConfigService implements ConfigObject {
   exportWithSheetBoundboarders: boolean;
   exportWithSheetsSpace: boolean;
   exportWithSheetsSpaceValue: number;
+  showNotifications: boolean;
   access_token?: string;
   id_token?: string;
 
@@ -130,6 +133,7 @@ export class ConfigService implements ConfigObject {
     this.exportWithSheetBoundboarders = this.config.exportWithSheetBoundboarders;
     this.exportWithSheetsSpace = this.config.exportWithSheetsSpace;
     this.exportWithSheetsSpaceValue = this.config.exportWithSheetsSpaceValue;
+    this.showNotifications = this.config.showNotifications;
   }
 
   /**

--- a/main/ui/types/index.ts
+++ b/main/ui/types/index.ts
@@ -37,6 +37,8 @@ export interface UIConfig extends DeepNestConfig {
   exportWithSheetsSpace: boolean;
   /** Space value between sheets in SVG units (default: 10mm) */
   exportWithSheetsSpaceValue: number;
+  /** Show product/update notifications fetched from deepnest.net (default: true) */
+  showNotifications: boolean;
 }
 
 /**


### PR DESCRIPTION
## What
The product/update notification popup (the one that recently showed the April-1st Patreon-support message) had two problems reported by a user:

1. **It forced itself above every other window on the OS** and, on some Linux WMs, kept re-raising over other applications. Cause: the window was created with `alwaysOnTop: true` **and** `type: "notification"` (`main.js`).
2. **No way to turn notifications off.**

## Changes
- **`main.js`** — drop `alwaysOnTop: true` and `type: "notification"`. The window is already `modal: true` with `parent: mainWindow`, so it still appears above deepnest's own window, but no longer hijacks the whole desktop.
- **Opt-out setting** — new `showNotifications` boolean config (Config → *Other Settings*, **default ON**). When unchecked, `runNotificationCheck()` returns early and the app **never fetches `deepnest.net/app_notifications.json`** — fully offline for notifications. Wired through `DEFAULT_CONFIG`, `BOOLEAN_CONFIG_KEYS`, the `UIConfig`/`ConfigObject` types, and a checkbox in `index.html` (auto-binds via the existing `[data-config]` mechanism).

## Not in scope
The notification **content** is served from `deepnest.net/app_notifications.json`, so *which* messages appear is controlled server-side — this PR only changes display behaviour and adds the local opt-out.

## Verification
- `tsc` compiles clean (regenerates `build/ui` at dist time).
- `node --check main.js` passes.
- Default-ON preserves current behaviour for existing users; the always-on-top fix applies regardless of the setting.